### PR TITLE
[FEAT-14] TextArea, Chip 컴포넌트 구현

### DIFF
--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,6 +1,5 @@
 import Button from '@/components/button/button';
 import { Meta, StoryObj } from '@storybook/react';
-import { describe } from 'node:test';
 
 const meta = {
   title: 'Components/Button',

--- a/src/components/chip/chip.stories.tsx
+++ b/src/components/chip/chip.stories.tsx
@@ -1,0 +1,38 @@
+import Chip from './chip';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Chip',
+  component: Chip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'text',
+      description: 'error / success',
+    },
+    label: {
+      control: 'text',
+      description: '칩 내부 콘텐츠',
+    },
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof Chip>;
+
+export const ErrorChip: Story = {
+  args: {
+    status: 'error',
+    label: '레이블',
+  },
+};
+
+export const SuccessChip: Story = {
+  args: {
+    status: 'success',
+    label: '레이블',
+  },
+};

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { cn } from '@/utils/style';
+
+type ChipProps = {
+  label: string;
+  status: 'success' | 'error';
+};
+
+function Chip({ label, status }: ChipProps) {
+  const baseStyle = 'w-fit rounded px-3 py-1.5 text-xs font-semibold ring-1 ring-inset';
+
+  const statusStyle = cn(
+    status === 'error' && 'ring-error bg-error/10 text-error',
+    status === 'success' && 'ring-success bg-success/10 text-success',
+  );
+
+  return <div className={cn(baseStyle, statusStyle)}>{label}</div>;
+}
+
+export default Chip;

--- a/src/components/text-area/text-area.stories.tsx
+++ b/src/components/text-area/text-area.stories.tsx
@@ -1,0 +1,24 @@
+import TextArea from './text-area';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/TextArea',
+  component: TextArea,
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+export const TextAreaVariant: Story = {
+  args: {
+    variant: 'textArea',
+    placeHolder: '플레이스홀더',
+  },
+};
+
+export const InputVariant: Story = {
+  args: {
+    variant: 'input',
+    placeHolder: '플레이스홀더',
+  },
+};

--- a/src/components/text-area/text-area.tsx
+++ b/src/components/text-area/text-area.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { cn } from '@/utils/style';
+import React, { useState } from 'react';
+
+type TextAreaProps = {
+  placeHolder: string;
+  variant: 'textArea' | 'input';
+};
+
+function TextArea({ placeHolder, variant }: TextAreaProps) {
+  const rows = variant === 'textArea' ? 4 : 1;
+
+  const baseStyle =
+    'resize-none rounded-lg border border-grayscale-gray-20 focus:outline-none bg-monotone-white p-3 text-grayscale-gray-80 placeholder:text-grayscale-gray-50 text-sm font-medium';
+  const variantStyle = cn(variant === 'textArea' && 'w-[1032px]', variant === 'input' && 'w-[240px]');
+  const textAreaStyle = cn(baseStyle, variantStyle);
+
+  const [text, setText] = useState('');
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+  };
+  return <textarea className={textAreaStyle} rows={rows} placeholder={placeHolder} value={text} onChange={onChange} />;
+}
+
+export default TextArea;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -34,6 +34,7 @@ export default {
           sunday: '#FE4A4A',
         },
         error: '#F60000',
+        success: '#00B93E',
       },
       fontFamily: {
         sans: ['Pretendard', 'sans-serif'],


### PR DESCRIPTION
## 📝 PR 내용
- TextArea, Input 컴포넌트 구현
- Chip 컴포넌트 구현 


## 📸 스크린 샷 / 영상 (선택)
- TextArea 컴포넌트
![image](https://github.com/user-attachments/assets/d279a9c5-23df-46c7-916a-0abccb3d3236)

- Input 컴포넌트
![image](https://github.com/user-attachments/assets/0c4a8a4e-0d7d-455f-abdc-6f4a977e5caa)

- Chip 컴포넌트
![image](https://github.com/user-attachments/assets/06531634-55c4-401e-91aa-7c6564437c38)
![image](https://github.com/user-attachments/assets/38304bf6-c187-473a-a58e-d9e619d0025d)

## 🔗 연관 이슈

<!-- 관련된 이슈를 링크해주세요 -->

- Closes #14 