### PR TITLE
fix: data fetching 부분 client component로 분리

### DIFF
--- a/src/app/(dashboard)/question-list/_components/question-list-skeleton.tsx
+++ b/src/app/(dashboard)/question-list/_components/question-list-skeleton.tsx
@@ -1,0 +1,39 @@
+export function QuestionListSkeleton() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-7 w-28 rounded bg-gray-200" />
+
+      <div className="flex items-end gap-6">
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-24 rounded bg-gray-200" />
+          <div className="h-9 w-40 rounded bg-gray-200" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-16 rounded bg-gray-200" />
+          <div className="flex gap-2">
+            <div className="h-7 w-12 rounded bg-gray-200" />
+            <div className="h-7 w-12 rounded bg-gray-200" />
+            <div className="h-7 w-16 rounded bg-gray-200" />
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded border border-gray-200">
+        <div className="flex bg-gray-50 px-4 py-3 gap-4">
+          <div className="h-4 rounded bg-gray-300" style={{ flexBasis: '75%' }} />
+          <div className="h-4 w-16 rounded bg-gray-300" style={{ flexBasis: '10%' }} />
+          <div className="h-4 w-16 rounded bg-gray-300" style={{ flexBasis: '10%' }} />
+          <div style={{ flexBasis: '5%' }} />
+        </div>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} className="flex border-t border-gray-100 px-4 py-3 gap-4 items-center">
+            <div className="h-4 rounded bg-gray-200" style={{ flexBasis: '70%' }} />
+            <div className="h-4 w-8 rounded bg-gray-200" style={{ flexBasis: '10%' }} />
+            <div className="h-5 w-14 rounded-full bg-gray-200" style={{ flexBasis: '10%' }} />
+            <div style={{ flexBasis: '5%' }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/question-list/hooks/use-questions-query.ts
+++ b/src/app/(dashboard)/question-list/hooks/use-questions-query.ts
@@ -1,9 +1,9 @@
 import { getQuestions } from '@/api/questions';
 import type { AdmissionType } from '@/types/admission';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 export function useQuestionsQuery(type: AdmissionType) {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['questions', type],
     queryFn: () => getQuestions({ type }),
   });

--- a/src/app/(dashboard)/question-list/page.tsx
+++ b/src/app/(dashboard)/question-list/page.tsx
@@ -1,18 +1,11 @@
-import { getQuestions } from '@/api/questions';
+import { QuestionListSkeleton } from '@/app/(dashboard)/question-list/_components/question-list-skeleton';
 import QuestionListClient from '@/app/(dashboard)/question-list/question-list-client';
-import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+import { Suspense } from 'react';
 
-export default async function QuestionList() {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ['questions', 'SUSI'],
-    queryFn: () => getQuestions({ type: 'SUSI' }),
-  });
-
+export default function QuestionList() {
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
+    <Suspense fallback={<QuestionListSkeleton />}>
       <QuestionListClient />
-    </HydrationBoundary>
+    </Suspense>
   );
 }


### PR DESCRIPTION
…Query

- Remove blocking `await prefetchQuery` in page.tsx; wrap client with `<Suspense>` + skeleton fallback so the page renders immediately
- Migrate `useQuestionsQuery` from `useQuery` to `useSuspenseQuery` for cleaner data guarantee (data is always defined)
- Add `QuestionListSkeleton` component matching the 4-column table layout with pulse animation
- Use `useTransition` for admission-type switching to keep current data visible (opacity 50%) while new data loads, avoiding a full Suspense re-trigger

https://claude.ai/code/session_01NRN9xXzHfXrPxHo6NTz2Q5

## 📝 PR 내용

<!-- 작업 내용과 관련된 설명을 적어주세요 -->

## ✅ 작업 내용

<!-- 리뷰어가 중점적으로 봐야 하는 부분을 상세히 나열해주세요 -->

## 📸 스크린 샷 / 영상 (선택)

<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요 -->
![comet_BwUvpiPX4O](https://github.com/user-attachments/assets/81742fc0-d945-4488-b56e-9d53c7912576)


## 🤔 고민 했던 부분 (선택)

<!-- 작업 중 고민했던 부분과 해결 방법을 공유해주세요 -->

- 문제:
- 해결:
- 리뷰어의 의견이 필요한 부분:

## 🔗 연관 이슈

<!-- 관련된 이슈를 링크해주세요 -->

- Closes #
