### PR TITLE
[FEAT-41] 입학 전형 상세 타입 관리 페이지 구현

### DIFF
--- a/src/api/swagger/admission.ts
+++ b/src/api/swagger/admission.ts
@@ -6,7 +6,29 @@ export async function getAdmissionsStatus(): Promise<{ type: AdmissionType; isAc
   return response.data;
 }
 
-export async function changeAdmissionStatus(admission: 'SUSI' | 'JEONGSI' | 'PYEONIP') {
+export async function changeAdmissionStatus(admission: AdmissionType) {
   const response = await spring_server_api_axiosInstance.put('/admin/questions/status', { type: admission });
+  return response.data;
+}
+
+export async function getAdmissionDetailsByType(
+  type: AdmissionType,
+): Promise<{ id: number; name: string; type: AdmissionType }[]> {
+  const response = await spring_server_api_axiosInstance.get(`/admissions/details/${type}`);
+  return response.data;
+}
+
+export async function createAdmissionsDetail(params: { type: AdmissionType; detail: string }) {
+  const response = await spring_server_api_axiosInstance.post(`/admin/admissions/detail`, params);
+  return response.data;
+}
+
+export async function deleteAdmissionDetail(id: string) {
+  const response = await spring_server_api_axiosInstance.delete(`/admin/admissions/${id}`);
+  return response.data;
+}
+
+export async function updateAdmissionDetail({ id, name }: { id: number; name: string }) {
+  const response = await spring_server_api_axiosInstance.put(`/admin/admissions/${id}`, { name });
   return response.data;
 }

--- a/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
+++ b/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import {
+  useCreateAdmissionDetailMutation,
+  useUpdateAdmissionDetailMutation,
+} from '../hooks/use-admission-detail-mutations';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { AdmissionType } from '@/types/admission';
+import { useState } from 'react';
+
+type CreateProps = {
+  mode: 'create';
+  type: AdmissionType;
+  detail?: never;
+  children: React.ReactNode;
+};
+
+type EditProps = {
+  mode: 'edit';
+  type: AdmissionType;
+  detail: { id: number; name: string };
+  children: React.ReactNode;
+};
+
+type AdmissionDetailFormDialogProps = CreateProps | EditProps;
+
+function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDetailFormDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(mode === 'edit' ? detail.name : '');
+
+  const { mutate: create, isPending: isCreating } = useCreateAdmissionDetailMutation();
+  const { mutate: update, isPending: isUpdating } = useUpdateAdmissionDetailMutation(type);
+  const isPending = isCreating || isUpdating;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setName(mode === 'edit' ? detail.name : '');
+    }
+    setOpen(nextOpen);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (mode === 'create') {
+      create({ type, detail: name }, { onSuccess: () => setOpen(false) });
+    } else {
+      update({ id: detail.id, name }, { onSuccess: () => setOpen(false) });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild onClick={(e) => e.stopPropagation()}>
+        {children}
+      </DialogTrigger>
+      <DialogContent className="max-w-md" onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>{mode === 'create' ? '상세 타입 추가' : '상세 타입 수정'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-gray-700">
+              상세 타입 이름 <span className="text-red-500">*</span>
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예) 일반전형"
+              required
+            />
+          </div>
+          <DialogFooter className="mt-2">
+            <Button type="submit" disabled={!name.trim() || isPending} className="w-full">
+              {isPending ? '처리 중...' : mode === 'create' ? '추가하기' : '수정하기'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default AdmissionDetailFormDialog;

--- a/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
+++ b/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
@@ -87,7 +87,11 @@ function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDe
             )}
           </div>
           <DialogFooter className="mt-2">
-            <Button type="submit" disabled={!name.trim() || !isFormatValid || isPending} className="w-full">
+            <Button
+              type="submit"
+              disabled={!name.trim() || !isFormatValid || isPending}
+              className="w-full bg-primary-maru hover:bg-opacity-70"
+            >
               {isPending ? '처리 중...' : mode === 'create' ? '추가하기' : '수정하기'}
             </Button>
           </DialogFooter>

--- a/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
+++ b/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
@@ -35,8 +35,8 @@ function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDe
   const { mutate: update, isPending: isUpdating } = useUpdateAdmissionDetailMutation(type);
   const isPending = isCreating || isUpdating;
 
-  const hasParentheses = /\(.+\)/.test(name);
-  const showFormatWarning = name.trim().length > 0 && !hasParentheses;
+  const isFormatValid = /\(.+\)/.test(name);
+  const showFormatError = name.trim().length > 0 && !isFormatValid;
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
@@ -74,22 +74,22 @@ function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDe
               placeholder="예) 학생부종합(계열 모집)"
               required
             />
-            {showFormatWarning ? (
-              <p className="flex items-center gap-1 text-xs text-amber-500">
+            {showFormatError ? (
+              <p className="flex items-center gap-1 text-xs text-red-500">
                 <TriangleAlert size={12} />
-                권장 형식: <span className="font-medium">대전형(소전형)</span>
-                &nbsp;예) 학생부종합(계열 모집)
+                형식이 올바르지 않아요.{' '}
+                <span className="font-medium">대전형(소전형)</span> 형식을 사용해주세요.
               </p>
             ) : (
               <p className="text-xs text-gray-400">
-                권장 형식:{' '}
+                입력 형식:{' '}
                 <span className="font-medium text-gray-500">대전형(소전형)</span>
                 &nbsp;·&nbsp; 예) 학생부종합(계열 모집)
               </p>
             )}
           </div>
           <DialogFooter className="mt-2">
-            <Button type="submit" disabled={!name.trim() || isPending} className="w-full">
+            <Button type="submit" disabled={!name.trim() || !isFormatValid || isPending} className="w-full">
               {isPending ? '처리 중...' : mode === 'create' ? '추가하기' : '수정하기'}
             </Button>
           </DialogFooter>

--- a/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
+++ b/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
@@ -64,15 +64,14 @@ function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDe
             <label className="text-sm font-medium text-gray-700">
               상세 타입 이름 <span className="text-red-500">*</span>
             </label>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="예) 일반전형"
-              required
-            />
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="예) 일반전형" required />
           </div>
           <DialogFooter className="mt-2">
-            <Button type="submit" disabled={!name.trim() || isPending} className="w-full">
+            <Button
+              type="submit"
+              disabled={!name.trim() || isPending}
+              className="w-full bg-primary-maru hover:bg-opacity-70"
+            >
               {isPending ? '처리 중...' : mode === 'create' ? '추가하기' : '수정하기'}
             </Button>
           </DialogFooter>

--- a/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
+++ b/src/app/(dashboard)/admission-detail/_components/admission-detail-form-dialog.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { AdmissionType } from '@/types/admission';
+import { TriangleAlert } from 'lucide-react';
 import { useState } from 'react';
 
 type CreateProps = {
@@ -33,6 +34,9 @@ function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDe
   const { mutate: create, isPending: isCreating } = useCreateAdmissionDetailMutation();
   const { mutate: update, isPending: isUpdating } = useUpdateAdmissionDetailMutation(type);
   const isPending = isCreating || isUpdating;
+
+  const hasParentheses = /\(.+\)/.test(name);
+  const showFormatWarning = name.trim().length > 0 && !hasParentheses;
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
@@ -67,9 +71,22 @@ function AdmissionDetailFormDialog({ mode, type, detail, children }: AdmissionDe
             <Input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="예) 일반전형"
+              placeholder="예) 학생부종합(계열 모집)"
               required
             />
+            {showFormatWarning ? (
+              <p className="flex items-center gap-1 text-xs text-amber-500">
+                <TriangleAlert size={12} />
+                권장 형식: <span className="font-medium">대전형(소전형)</span>
+                &nbsp;예) 학생부종합(계열 모집)
+              </p>
+            ) : (
+              <p className="text-xs text-gray-400">
+                권장 형식:{' '}
+                <span className="font-medium text-gray-500">대전형(소전형)</span>
+                &nbsp;·&nbsp; 예) 학생부종합(계열 모집)
+              </p>
+            )}
           </div>
           <DialogFooter className="mt-2">
             <Button type="submit" disabled={!name.trim() || isPending} className="w-full">

--- a/src/app/(dashboard)/admission-detail/_components/admission-detail-item.tsx
+++ b/src/app/(dashboard)/admission-detail/_components/admission-detail-item.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import AdmissionDetailFormDialog from './admission-detail-form-dialog';
+import { useDeleteAdmissionDetailMutation } from '../hooks/use-admission-detail-mutations';
+import DeleteConfirmDialog from '@/components/delete-confirm-dialog/delete-confirm-dialog';
+import { AdmissionType } from '@/types/admission';
+import { Pencil, Trash2 } from 'lucide-react';
+
+type AdmissionDetailItemProps = {
+  detail: { id: number; name: string };
+  type: AdmissionType;
+};
+
+function AdmissionDetailItem({ detail, type }: AdmissionDetailItemProps) {
+  const { mutate: deleteDetail } = useDeleteAdmissionDetailMutation(type);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-3 transition-colors first:rounded-t-xl last:rounded-b-xl hover:bg-gray-50">
+      <span className="text-sm font-medium text-gray-800">{detail.name}</span>
+      <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+        <AdmissionDetailFormDialog mode="edit" type={type} detail={detail}>
+          <button
+            type="button"
+            className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+          >
+            <Pencil size={13} />
+          </button>
+        </AdmissionDetailFormDialog>
+        <DeleteConfirmDialog
+          name={`"${detail.name}" 타입을 삭제하시겠어요?`}
+          description="삭제된 상세 타입은 복구할 수 없어요."
+          onConfirm={() => deleteDetail(String(detail.id))}
+        >
+          <button
+            type="button"
+            className="rounded p-1 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500"
+          >
+            <Trash2 size={13} />
+          </button>
+        </DeleteConfirmDialog>
+      </div>
+    </div>
+  );
+}
+
+export default AdmissionDetailItem;

--- a/src/app/(dashboard)/admission-detail/admission-detail-client.tsx
+++ b/src/app/(dashboard)/admission-detail/admission-detail-client.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import AdmissionDetailFormDialog from './_components/admission-detail-form-dialog';
+import AdmissionDetailItem from './_components/admission-detail-item';
+import { useAdmissionDetailsQuery } from './hooks/use-admission-details-query';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { ADMISSIONS, AdmissionType } from '@/types/admission';
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+
+const ADMISSION_TABS = Object.entries(ADMISSIONS) as [AdmissionType, string][];
+
+function AdmissionDetailClient() {
+  const [selectedType, setSelectedType] = useState<AdmissionType>('SUSI');
+
+  const { data: details = [] } = useAdmissionDetailsQuery(selectedType);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-gray-900">입학 전형 상세 타입 관리</h1>
+      </div>
+
+      <div className="flex gap-0 border-b border-gray-200">
+        {ADMISSION_TABS.map(([type, label]) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => setSelectedType(type)}
+            className={cn(
+              'px-6 py-3 text-sm font-semibold transition-colors',
+              selectedType === type
+                ? 'border-b-2 border-primary-maru text-primary-maru'
+                : 'text-gray-500 hover:text-gray-700',
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold text-gray-700">상세 타입 목록</span>
+          <span className="text-xs text-gray-400">{details.length}개</span>
+        </div>
+
+        <div className="flex flex-col divide-y overflow-hidden rounded-xl border border-gray-200">
+          {details.map((detail) => (
+            <AdmissionDetailItem key={detail.id} detail={detail} type={selectedType} />
+          ))}
+          {details.length === 0 && (
+            <p className="px-4 py-8 text-center text-sm text-gray-400">등록된 상세 타입이 없어요</p>
+          )}
+        </div>
+
+        <AdmissionDetailFormDialog mode="create" type={selectedType}>
+          <Button variant="outline" className="flex w-full items-center justify-center gap-1">
+            <Plus size={14} />
+            상세 타입 추가
+          </Button>
+        </AdmissionDetailFormDialog>
+      </div>
+    </div>
+  );
+}
+
+export default AdmissionDetailClient;

--- a/src/app/(dashboard)/admission-detail/hooks/use-admission-detail-mutations.ts
+++ b/src/app/(dashboard)/admission-detail/hooks/use-admission-detail-mutations.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import {
+  createAdmissionsDetail,
+  deleteAdmissionDetail,
+  updateAdmissionDetail,
+} from '@/api/swagger/admission';
+import { toast } from '@/components/toast';
+import { AdmissionType } from '@/types/admission';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useCreateAdmissionDetailMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createAdmissionsDetail,
+    onSuccess: (_, variables) => {
+      toast.open({ type: 'success', position: 'top-center', message: '상세 타입이 추가되었어요' });
+      queryClient.refetchQueries({ queryKey: ['admissionDetails', variables.type] });
+    },
+    onError: () => {
+      toast.open({ type: 'error', position: 'top-center', message: '상세 타입 추가에 실패했어요' });
+    },
+  });
+}
+
+export function useUpdateAdmissionDetailMutation(type: AdmissionType) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateAdmissionDetail,
+    onSuccess: () => {
+      toast.open({ type: 'success', position: 'top-center', message: '상세 타입이 수정되었어요' });
+      queryClient.refetchQueries({ queryKey: ['admissionDetails', type] });
+    },
+    onError: () => {
+      toast.open({ type: 'error', position: 'top-center', message: '상세 타입 수정에 실패했어요' });
+    },
+  });
+}
+
+export function useDeleteAdmissionDetailMutation(type: AdmissionType) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteAdmissionDetail,
+    onSuccess: () => {
+      toast.open({ type: 'success', position: 'top-center', message: '상세 타입이 삭제되었어요' });
+      queryClient.refetchQueries({ queryKey: ['admissionDetails', type] });
+    },
+    onError: () => {
+      toast.open({ type: 'error', position: 'top-center', message: '상세 타입 삭제에 실패했어요' });
+    },
+  });
+}

--- a/src/app/(dashboard)/admission-detail/hooks/use-admission-details-query.ts
+++ b/src/app/(dashboard)/admission-detail/hooks/use-admission-details-query.ts
@@ -1,0 +1,10 @@
+import { getAdmissionDetailsByType } from '@/api/swagger/admission';
+import { AdmissionType } from '@/types/admission';
+import { useQuery } from '@tanstack/react-query';
+
+export function useAdmissionDetailsQuery(type: AdmissionType) {
+  return useQuery({
+    queryKey: ['admissionDetails', type],
+    queryFn: () => getAdmissionDetailsByType(type),
+  });
+}

--- a/src/app/(dashboard)/admission-detail/page.tsx
+++ b/src/app/(dashboard)/admission-detail/page.tsx
@@ -1,3 +1,19 @@
-export default function AdmissionDetail() {
-  return <div>admission-detail</div>;
+import { getAdmissionDetailsByType } from '@/api/swagger/admission';
+import AdmissionDetailClient from '@/app/(dashboard)/admission-detail/admission-detail-client';
+import { QueryClient } from '@tanstack/react-query';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+
+export default async function AdmissionDetail() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['admissionDetails', 'SUSI'],
+    queryFn: () => getAdmissionDetailsByType('SUSI'),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <AdmissionDetailClient />
+    </HydrationBoundary>
+  );
 }


### PR DESCRIPTION
## 📝 PR 내용

<!-- 작업 내용과 관련된 설명을 적어주세요 -->
수시/정시/편입학 전형별로 상세 타입을 조회·추가·수정·삭제할 수 있는
`/admission-detail` 페이지를 구현했습니다.

## ✅ 작업 내용

<!-- 리뷰어가 중점적으로 봐야 하는 부분을 상세히 나열해주세요 -->

### 페이지 구조
- 서버 컴포넌트에서 `SUSI` 타입 데이터 prefetch 후 HydrationBoundary로 전달
- 수시 / 정시 / 편입학 탭 전환 시 해당 전형의 상세 타입 목록 로드

### CRUD 기능
- **조회**: TanStack Query로 타입별 상세 목록 페칭, 탭 전환 시 캐시 활용
- **추가**: "상세 타입 추가" 버튼 → Dialog에서 이름 입력 후 저장
- **수정**: 각 항목의 연필 아이콘 → 기존 이름 pre-fill된 Dialog에서 수정
- **삭제**: 휴지통 아이콘 → 삭제 확인 Dialog 후 삭제
- 각 동작 성공/실패 시 toast 알림 표시

### 입력 형식 강제
- `대전형(소전형)` 형식 검증 — 괄호가 없으면 저장 버튼 비활성화
- 형식 불일치 시 빨간 에러 메시지 표시, 올바른 형식 입력 시 회색 힌트로 복귀
## 파일 구조


src/app/(dashboard)/admission-detail/
page.tsx # 서버 컴포넌트 (prefetch)
admission-detail-client.tsx # 탭 UI + 목록 렌더링
_components/
admission-detail-form-dialog.tsx # 추가/수정 Dialog
admission-detail-item.tsx # 개별 항목 (수정/삭제 버튼)
hooks/
use-admission-details-query.ts # 목록 조회 쿼리
use-admission-detail-mutations.ts # create / update / delete 뮤테이션

## 📸 스크린 샷 / 영상 (선택)
![comet_yPwqDDU1eT](https://github.com/user-attachments/assets/49372508-5991-4cb6-884d-0789e7c6c3bb)

<!-- UI 변경사항이 있다면 스크린샷이나 영상을 첨부해주세요 -->

## 🤔 고민 했던 부분 (선택)

<!-- 작업 중 고민했던 부분과 해결 방법을 공유해주세요 -->

- 문제:
- 해결:
- 리뷰어의 의견이 필요한 부분:

## 🔗 연관 이슈

<!-- 관련된 이슈를 링크해주세요 -->

- Closes #41
